### PR TITLE
Make flake8 configurable by project

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -13,6 +13,12 @@ ignore =
     # multiple spaces after keyword
     E272,
     # missing docstring in public method
-    D102
+    D102,
+    # format string does contain unindexed parameter
+    P101,
+    # docstring does contain unindexed parameters
+    P102,
+    # other string does contain unindexed parameters
+    P103
 
 jobs=auto

--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,18 @@
+[flake8]
+ignore =
+    # whitespace before ':'
+    E203,
+    # multiple spaces before operator
+    E221,
+    # multiple spaces after operator
+    E222,
+    # multiple spaces after ','
+    E241,
+    # unexpected spaces around keyword / parameter equals
+    E251,
+    # multiple spaces after keyword
+    E272,
+    # missing docstring in public method
+    D102
+
+jobs=auto

--- a/Makefile
+++ b/Makefile
@@ -76,8 +76,11 @@ coala: | .deps/coalib  ## Guided additional code-analysis (more than the minimum
 	fi
 endif
 
-flake8: | .deps/flake8  ## Run flake8 test
-	flake8 -j auto --ignore=E221,E222,E251,E272,E241,E203,S001,D102 $(PROJECT)
+.flake8:
+	cp pyproject/.flake8 .flake8
+
+flake8: .flake8 | .deps/flake8  ## Run flake8 test
+	flake8 $(PROJECT)
 
 todo:  ## Show todos in code
 	grep -Inrs TODO $(PROJECT) Makefile; true

--- a/Makefile
+++ b/Makefile
@@ -144,7 +144,7 @@ pypi:  ## Release package to pypi
 	pip install --upgrade isort
 	@pyenv rehash > /dev/null 2> /dev/null; true
 
-.deps/flake8: | .deps/flake8_mock .deps/flake8_tuple .deps/flake8_pep3101 .deps/flake8_debugger .deps/flake8_deprecated .deps/flake8_comprehensions
+.deps/flake8: | .deps/flake8_mock .deps/flake8_tuple .deps/flake8_string_format .deps/flake8_debugger .deps/flake8_deprecated .deps/flake8_comprehensions
 	pip install --upgrade 'flake8<3.0.0'
 	@pyenv rehash > /dev/null 2> /dev/null; true
 
@@ -154,8 +154,8 @@ pypi:  ## Release package to pypi
 .deps/flake8_tuple:
 	pip install --upgrade flake8-tuple -r pyproject/.flake8-req.txt
 
-.deps/flake8_pep3101:
-	pip install --upgrade flake8-pep3101 -r pyproject/.flake8-req.txt
+.deps/flake8_string_format:
+	pip install --upgrade flake8-string-format -r pyproject/.flake8-req.txt
 
 .deps/flake8_debugger:
 	pip install --upgrade flake8-debugger -r pyproject/.flake8-req.txt

--- a/depends
+++ b/depends
@@ -1,7 +1,7 @@
 flake8
 flake8_mock
 flake8_tuple
-flake8_pep3101
+flake8_string_format
 flake8_docstrings
 flake8_debugger
 flake8_deprecated


### PR DESCRIPTION
- Introduced .flake8 file to make flake8 configurable by project if desired
- Additionally added comments in flake8 config file to clarify what codes are being ignored
- replaced pep3101 dependency which was disabled with code S001 anyway and replacing it with flake8-string-format which properly checks string formats.
