### PR TITLE
use useradd instead of adduser

### DIFF
--- a/docker.mk
+++ b/docker.mk
@@ -62,6 +62,6 @@ image: | .images .images/$(IMAGE_NAME)  ## Build the image
 .images/$(IMAGE_NAME): | .images
 	echo export HUID=\"$(shell id -u)\" > $(DOCKER_DIR)/hid.sh
 	echo export HNAME=\"$(shell id -n -u)\" >> $(DOCKER_DIR)/hid.sh
-	echo 'adduser -u "$$HUID" "$$HNAME" 2> /dev/null' >> $(DOCKER_DIR)/hid.sh
+	echo 'useradd -u "$$HUID" "$$HNAME" 2> /dev/null' >> $(DOCKER_DIR)/hid.sh
 	chmod u+x $(DOCKER_DIR)/hid.sh
 	$(SCMD) docker build -t $(IMAGE_NAME) $(DOCKER_DIR)

--- a/docker.mk
+++ b/docker.mk
@@ -62,6 +62,10 @@ image: | .images .images/$(IMAGE_NAME)  ## Build the image
 .images/$(IMAGE_NAME): | .images
 	echo export HUID=\"$(shell id -u)\" > $(DOCKER_DIR)/hid.sh
 	echo export HNAME=\"$(shell id -n -u)\" >> $(DOCKER_DIR)/hid.sh
-	echo 'useradd -u "$$HUID" "$$HNAME" 2> /dev/null' >> $(DOCKER_DIR)/hid.sh
+	echo 'if which useradd; then' >> $(DOCKER_DIR)/hid.sh
+	echo '    useradd -u "$$HUID" "$$HNAME" 2> /dev/null' >> $(DOCKER_DIR)/hid.sh
+	echo 'else' >> $(DOCKER_DIR)/hid.sh
+	echo '    adduser -u "$$HUID" "$$HNAME" 2> /dev/null' >> $(DOCKER_DIR)/hid.sh
+	echo 'fi' >> $(DOCKER_DIR)/hid.sh
 	chmod u+x $(DOCKER_DIR)/hid.sh
 	$(SCMD) docker build -t $(IMAGE_NAME) $(DOCKER_DIR)


### PR DESCRIPTION
Use ``useradd`` instead of ``adduser`` because ``adduser`` is just a perl wrapper around ``useradd`` and less often available.